### PR TITLE
feat: Add --fast-index option for MP4 moov atom placement

### DIFF
--- a/src/cleanvid/gui/cleanvidgui_action_output.py
+++ b/src/cleanvid/gui/cleanvidgui_action_output.py
@@ -139,6 +139,7 @@ class ActionOutputFrame(ctk.CTkFrame):
         audio_stream_index = self.options_frame.audio_stream_index_var.get()
         threads = self.options_frame.threads_var.get()
         chapter_markers = self.options_frame.chapter_markers_var.get() # Get chapter markers state
+        fast_index = self.options_frame.fast_index_var.get() # Add this
 
 
         # --- Input Validation ---
@@ -246,6 +247,9 @@ class ActionOutputFrame(ctk.CTkFrame):
 
         if chapter_markers:
             cmd.append("--chapter")
+
+        if fast_index: # Add this block
+            cmd.append("--fast-index")
 
         # --- Execute in Thread ---
         self.output_console.configure(state="normal")

--- a/src/cleanvid/gui/cleanvidgui_config.py
+++ b/src/cleanvid/gui/cleanvidgui_config.py
@@ -16,6 +16,7 @@ DEFAULT_CONFIG = {
     "last_subs_dir": str(Path.home()),
     "window_geometry": "800x750", # Default window size
     "chapter_markers": False,
+    "fast_index": False, # Add this
 }
 
 class ConfigManager:

--- a/src/cleanvid/gui/cleanvidgui_options.py
+++ b/src/cleanvid/gui/cleanvidgui_options.py
@@ -48,6 +48,7 @@ class OptionsFrame(ctk.CTkFrame):
         self.audio_stream_index_var = ctk.StringVar(value=self.config_manager.config.get("audio_stream_index", DEFAULT_CONFIG.get("audio_stream_index", ""))) # Use string for optional input
         self.threads_var = ctk.StringVar(value=self.config_manager.config.get("threads", DEFAULT_CONFIG.get("threads", ""))) # Use string for optional input
         self.chapter_markers_var = ctk.BooleanVar(value=self.config_manager.config.get("chapter_markers", DEFAULT_CONFIG.get("chapter_markers", False)))
+        self.fast_index_var = ctk.BooleanVar(value=self.config_manager.config.get("fast_index", DEFAULT_CONFIG.get("fast_index", False)))
 
 
         # --- Enable/Disable Variables for Optional Args ---
@@ -88,7 +89,7 @@ class OptionsFrame(ctk.CTkFrame):
         self.tab_view.add("Swears/Pad")
         self.tab_view.add("Output Formats")
         self.tab_view.add("Encoding/Audio")
-        self.tab_view.add("Chapters") # New Tab
+        self.tab_view.add("Misc") # Renamed Tab
 
         # --- Populate Tabs ---
         self._create_settings_tab(self.tab_view.tab("Settings"))
@@ -96,7 +97,7 @@ class OptionsFrame(ctk.CTkFrame):
         self._create_swears_pad_tab(self.tab_view.tab("Swears/Pad"))
         self._create_formats_tab(self.tab_view.tab("Output Formats"))
         self._create_encoding_audio_tab(self.tab_view.tab("Encoding/Audio"))
-        self._create_chapters_tab(self.tab_view.tab("Chapters")) # Create the new tab
+        self._create_misc_tab(self.tab_view.tab("Misc")) # Updated method call
 
 
     def _create_settings_tab(self, tab):
@@ -317,17 +318,27 @@ class OptionsFrame(ctk.CTkFrame):
         threads_enable_cb.configure(command=lambda: self._toggle_widget_state(self.enable_threads_var, threads_entry))
         self._toggle_widget_state(self.enable_threads_var, threads_entry)
 
-    def _create_chapters_tab(self, tab):
-        """Creates the content for the Chapters tab."""
-        tab.grid_columnconfigure(0, weight=1) # Allow checkbox to expand
+    def _create_misc_tab(self, tab):
+        """Creates the content for the Misc tab (formerly Chapters)."""
+        tab.grid_columnconfigure(0, weight=1) # Allow checkboxes to expand
 
+        # Existing Chapter Markers Checkbox
         self.chapter_markers_checkbox = ctk.CTkCheckBox(
-            tab, # Checkboxes frame is not used here, directly in tab
+            tab,
             text="Add Chapter Markers at Mute Points (--chapter)",
             variable=self.chapter_markers_var
         )
-        self.chapter_markers_checkbox.grid(row=0, column=0, padx=10, pady=(10, 10), sticky="w")
+        self.chapter_markers_checkbox.grid(row=0, column=0, padx=10, pady=(10, 5), sticky="w") # Adjust pady
         Tooltip(self.chapter_markers_checkbox, "(From README) Create chapter markers for muted segments in the video metadata.")
+
+        # New Fast Index Checkbox
+        self.fast_index_checkbox = ctk.CTkCheckBox(
+            tab,
+            text="Optimize for Streaming (--fast-index, MP4 only)",
+            variable=self.fast_index_var
+        )
+        self.fast_index_checkbox.grid(row=1, column=0, padx=10, pady=(5, 10), sticky="w") # Placed on a new row
+        Tooltip(self.fast_index_checkbox, "Moves metadata to the front of MP4 files for faster loading and seeking on some devices.")
 
 
     def _toggle_widget_state(self, enable_var, widgets):
@@ -370,6 +381,7 @@ class OptionsFrame(ctk.CTkFrame):
             "audio_stream_index": self.audio_stream_index_var.get(),
             "threads": self.threads_var.get(),
             "chapter_markers": self.chapter_markers_var.get(),
+            "fast_index": self.fast_index_var.get(), # Add this
             # Add enable states
             "enable_swears_file": self.enable_swears_file_var.get(),
             "enable_subtitle_lang": self.enable_subtitle_lang_var.get(),


### PR DESCRIPTION
This commit introduces a new feature to improve playback of cleaned MP4 videos on some smart TVs and devices by moving the moov atom (the fast seeking index) to the beginning of the file.

Changes include:

- Core Logic (`cleanvid.py`):
  - Added a `--fast-index` command-line argument.
  - The `VidCleaner` class now accepts a `fast_index` parameter.
  - If `fast_index` is true and the output is an MP4 file, `-movflags +faststart` is added to the ffmpeg command during the multiplexing stage. This applies to both standard and Windows-specific processing paths.

- GUI (`cleanvidgui_*.py` files):
  - Renamed the "Chapters" tab in Advanced Options to "Misc".
  - Added an "Optimize for Streaming (--fast-index, MP4 only)" checkbox to the "Misc" tab.
  - The state of this checkbox is saved in the configuration and loaded on startup.
  - The GUI now passes the `--fast-index` flag to `cleanvid.py` when the checkbox is enabled.
  - Added `fast_index` to `DEFAULT_CONFIG` in `cleanvidgui_config.py`.

This enhancement allows you to optionally optimize your MP4 files for better streaming and navigation performance on compatible players.